### PR TITLE
Expose options common to all checks in Check.Run.

### DIFF
--- a/checks/checks_test.go
+++ b/checks/checks_test.go
@@ -62,7 +62,7 @@ func TestChecksSuccess(t *testing.T) {
 			l.Lock()
 			l.Unlock()
 		}
-		if err := c.Run(change); err != nil {
+		if err := c.Run(change, &Options{MaxDuration: 1}); err != nil {
 			t.Errorf("%s failed: %s", c.GetName(), err)
 		}
 	}
@@ -108,7 +108,7 @@ func TestChecksFailure(t *testing.T) {
 			cov.PerDirDefault.MinCoverage = 100
 			cov.PerDirDefault.MaxCoverage = 100
 		}
-		if err := c.Run(change); err == nil {
+		if err := c.Run(change, &Options{MaxDuration: 1}); err == nil {
 			t.Errorf("%s didn't fail but was expected to", c.GetName())
 		}
 	}

--- a/checks/config_test.go
+++ b/checks/config_test.go
@@ -18,8 +18,8 @@ func TestConfigNew(t *testing.T) {
 	ut.AssertEqual(t, 3, len(config.Modes[PrePush].Checks))
 	ut.AssertEqual(t, 5, len(config.Modes[ContinuousIntegration].Checks))
 	ut.AssertEqual(t, 3, len(config.Modes[Lint].Checks))
-	checks, max := config.EnabledChecks([]Mode{PreCommit, PrePush, ContinuousIntegration, Lint})
-	ut.AssertEqual(t, 120, max)
+	checks, options := config.EnabledChecks([]Mode{PreCommit, PrePush, ContinuousIntegration, Lint})
+	ut.AssertEqual(t, Options{MaxDuration: 120}, *options)
 	ut.AssertEqual(t, 2+4+5+3, len(checks))
 }
 

--- a/checks/coverage_test.go
+++ b/checks/coverage_test.go
@@ -40,7 +40,7 @@ func TestCoverageGlobal(t *testing.T) {
 		},
 		PerDir: map[string]*CoverageSettings{},
 	}
-	profile, err := c.RunProfile(change)
+	profile, err := c.RunProfile(change, &Options{1})
 	ut.AssertEqual(t, nil, err)
 	expected := CoverageProfile{
 		{
@@ -144,7 +144,7 @@ func TestCoverageLocal(t *testing.T) {
 		},
 		PerDir: map[string]*CoverageSettings{},
 	}
-	profile, err := c.RunProfile(change)
+	profile, err := c.RunProfile(change, &Options{1})
 	ut.AssertEqual(t, nil, err)
 	expected := CoverageProfile{
 		{
@@ -206,7 +206,7 @@ func TestCoverageLocal(t *testing.T) {
 	}
 	ut.AssertEqual(t, expected, profile.Subset("bar"))
 
-	ut.AssertEqual(t, nil, c.Run(change))
+	ut.AssertEqual(t, nil, c.Run(change, &Options{MaxDuration: 1}))
 }
 
 var coverageFiles = map[string]string{

--- a/cmd/covg/main.go
+++ b/cmd/covg/main.go
@@ -86,7 +86,7 @@ func mainImpl() error {
 		return err
 	}
 	log.Printf("Packages: %s\n", change.All().TestPackages())
-	profile, err := c.RunProfile(change)
+	profile, err := c.RunProfile(change, &checks.Options{MaxDuration: 999})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
if test is slower than that given timeout, go test ends up almost the same way as if it was a panic: by printing all the goroutine states. So, either pcg should hide the output, or maybe pipe it through panic parse?