### PR TITLE
Add sharding.

### DIFF
--- a/checks/coverage.go
+++ b/checks/coverage.go
@@ -69,6 +69,10 @@ func (c *Coverage) Run(change scm.Change, options *Options) error {
 	}
 
 	if c.UseGlobalInference {
+		if !options.isSingleton() {
+			return nil
+		}
+
 		out, err := ProcessProfile(profile, &c.Global)
 		if out != "" {
 			log.Printf("coverage for %s:\n%s\n", change.Repo().Root(), out)
@@ -78,6 +82,10 @@ func (c *Coverage) Run(change scm.Change, options *Options) error {
 		}
 	} else {
 		for _, testPkg := range change.Indirect().TestPackages() {
+			if !options.isEnabled(testPkg) {
+				continue
+			}
+
 			p := profile.Subset(pkgToDir(testPkg))
 			settings := c.SettingsForPkg(testPkg)
 			if settings.MinCoverage == 0 {

--- a/checks/coverage_test.go
+++ b/checks/coverage_test.go
@@ -40,7 +40,7 @@ func TestCoverageGlobal(t *testing.T) {
 		},
 		PerDir: map[string]*CoverageSettings{},
 	}
-	profile, err := c.RunProfile(change, &Options{1})
+	profile, err := c.RunProfile(change, &Options{1, 0, 0})
 	ut.AssertEqual(t, nil, err)
 	expected := CoverageProfile{
 		{
@@ -144,7 +144,7 @@ func TestCoverageLocal(t *testing.T) {
 		},
 		PerDir: map[string]*CoverageSettings{},
 	}
-	profile, err := c.RunProfile(change, &Options{1})
+	profile, err := c.RunProfile(change, &Options{1, 0, 0})
 	ut.AssertEqual(t, nil, err)
 	expected := CoverageProfile{
 		{

--- a/cmd/pcg/main.go
+++ b/cmd/pcg/main.go
@@ -101,6 +101,12 @@ const yamlHeader = `# https://github.com/maruel/pre-commit-go configuration file
 
 var parsedVersion []int
 
+// Runtime Options.
+type application struct {
+	config *checks.Config
+	shards shardFlag
+}
+
 // Utils.
 
 func init() {
@@ -209,9 +215,12 @@ func callRun(check checks.Check, change scm.Change, options *checks.Options) (ti
 	return time.Now().Sub(start), err
 }
 
-func runChecks(config *checks.Config, change scm.Change, modes []checks.Mode, prereqReady *sync.WaitGroup) error {
-	enabledChecks, options := config.EnabledChecks(modes)
-	log.Printf("mode: %s; %d checks; %d max seconds allowed", modes, len(enabledChecks), options.MaxDuration)
+func (a *application) runChecks(change scm.Change, modes []checks.Mode, prereqReady *sync.WaitGroup) error {
+	enabledChecks, options := a.config.EnabledChecks(modes)
+	options.CurrentShard = a.shards.currentShard()
+	options.TotalShards = a.shards.totalShards()
+
+	log.Printf("mode: %s; %d checks; %d max seconds allowed; shard %s", modes, len(enabledChecks), options.MaxDuration, a.shards.String())
 	if change == nil {
 		log.Printf("no change")
 		return nil
@@ -263,7 +272,7 @@ func runChecks(config *checks.Config, change scm.Change, modes []checks.Mode, pr
 	}
 }
 
-func runPreCommit(repo scm.Repo, config *checks.Config) error {
+func (a *application) runPreCommit(repo scm.Repo) error {
 	// First, stash index and work dir, keeping only the to-be-committed changes
 	// in the working directory.
 	stashed, err := repo.Stash()
@@ -272,9 +281,9 @@ func runPreCommit(repo scm.Repo, config *checks.Config) error {
 	}
 	// Run the checks.
 	var change scm.Change
-	change, err = repo.Between(scm.Current, repo.HEAD(), config.IgnorePatterns)
+	change, err = repo.Between(scm.Current, repo.HEAD(), a.config.IgnorePatterns)
 	if change != nil {
-		err = runChecks(config, change, []checks.Mode{checks.PreCommit}, &sync.WaitGroup{})
+		err = a.runChecks(change, []checks.Mode{checks.PreCommit}, &sync.WaitGroup{})
 	}
 	// If stashed is false, everything was in the index so no stashing was needed.
 	if stashed {
@@ -285,7 +294,7 @@ func runPreCommit(repo scm.Repo, config *checks.Config) error {
 	return err
 }
 
-func runPrePush(repo scm.Repo, config *checks.Config) (err error) {
+func (a *application) runPrePush(repo scm.Repo) (err error) {
 	previous := repo.HEAD()
 	// Will be "" if the current checkout was detached.
 	previousRef := repo.Ref()
@@ -342,11 +351,11 @@ func runPrePush(repo scm.Repo, config *checks.Config) (err error) {
 		if from == gitNilCommit {
 			from = scm.GitInitialCommit
 		}
-		change, err := repo.Between(to, from, config.IgnorePatterns)
+		change, err := repo.Between(to, from, a.config.IgnorePatterns)
 		if err != nil {
 			return err
 		}
-		if err = runChecks(config, change, []checks.Mode{checks.PrePush}, &sync.WaitGroup{}); err != nil {
+		if err = a.runChecks(change, []checks.Mode{checks.PrePush}, &sync.WaitGroup{}); err != nil {
 			return err
 		}
 	}
@@ -390,7 +399,7 @@ func (s sortedChecks) Less(i, j int) bool { return s[i].GetName() < s[j].GetName
 
 // Commands.
 
-func cmdHelp(repo scm.ReadOnlyRepo, config *checks.Config, usage string) error {
+func (a *application) cmdHelp(repo scm.ReadOnlyRepo, usage string) error {
 	s := &struct {
 		Usage        string
 		Max          int
@@ -419,12 +428,12 @@ func cmdHelp(repo scm.ReadOnlyRepo, config *checks.Config, usage string) error {
 }
 
 // cmdInfo displays the current configuration used.
-func cmdInfo(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, configPath string) error {
+func (a *application) cmdInfo(repo scm.ReadOnlyRepo, modes []checks.Mode, configPath string) error {
 	fmt.Printf("File: %s\n", configPath)
 	fmt.Printf("Repo: %s\n", repo.Root())
 
-	fmt.Printf("MinVersion: %s\n", config.MinVersion)
-	content, err := yaml.Marshal(config.IgnorePatterns)
+	fmt.Printf("MinVersion: %s\n", a.config.MinVersion)
+	content, err := yaml.Marshal(a.config.IgnorePatterns)
 	if err != nil {
 		return err
 	}
@@ -434,7 +443,7 @@ func cmdInfo(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, 
 		modes = checks.AllModes
 	}
 	for _, mode := range modes {
-		settings := config.Modes[mode]
+		settings := a.config.Modes[mode]
 		maxLen := 0
 		for _, checks := range settings.Checks {
 			for _, check := range checks {
@@ -466,9 +475,9 @@ func cmdInfo(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, 
 }
 
 // cmdInstallPrereq installs all the packages needed to run the enabled checks.
-func cmdInstallPrereq(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, noUpdate bool) error {
+func (a *application) cmdInstallPrereq(repo scm.ReadOnlyRepo, modes []checks.Mode, noUpdate bool) error {
 	var wg sync.WaitGroup
-	enabledChecks, _ := config.EnabledChecks(modes)
+	enabledChecks, _ := a.config.EnabledChecks(modes)
 	number := 0
 	c := make(chan string, len(enabledChecks))
 	for _, check := range enabledChecks {
@@ -535,11 +544,11 @@ func cmdInstallPrereq(repo scm.ReadOnlyRepo, config *checks.Config, modes []chec
 //
 // Silently ignore installing the hooks when running under a CI. In
 // particular, circleci.com doesn't create the directory .git/hooks.
-func cmdInstall(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, noUpdate bool, prereqReady *sync.WaitGroup) (err error) {
+func (a *application) cmdInstall(repo scm.ReadOnlyRepo, modes []checks.Mode, noUpdate bool, prereqReady *sync.WaitGroup) (err error) {
 	errCh := make(chan error, 1)
 	go func() {
 		defer prereqReady.Done()
-		errCh <- cmdInstallPrereq(repo, config, modes, noUpdate)
+		errCh <- a.cmdInstallPrereq(repo, modes, noUpdate)
 	}()
 
 	defer func() {
@@ -570,7 +579,7 @@ func cmdInstall(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mod
 }
 
 // cmdRun runs all the enabled checks.
-func cmdRun(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, against string, prereqReady *sync.WaitGroup) error {
+func (a *application) cmdRun(repo scm.ReadOnlyRepo, modes []checks.Mode, against string, prereqReady *sync.WaitGroup) error {
 	var err error
 	var old scm.Commit
 	if against != "" {
@@ -582,28 +591,28 @@ func cmdRun(repo scm.ReadOnlyRepo, config *checks.Config, modes []checks.Mode, a
 			return err
 		}
 	}
-	change, err := repo.Between(scm.Current, old, config.IgnorePatterns)
+	change, err := repo.Between(scm.Current, old, a.config.IgnorePatterns)
 	if err != nil {
 		return err
 	}
-	return runChecks(config, change, modes, prereqReady)
+	return a.runChecks(change, modes, prereqReady)
 }
 
 // cmdRunHook runs the checks in a git repository.
 //
 // Use a precise "stash, run checks, unstash" to ensure that the check is
 // properly run on the data in the index.
-func cmdRunHook(repo scm.Repo, config *checks.Config, mode string, noUpdate bool) error {
+func (a *application) cmdRunHook(repo scm.Repo, mode string, noUpdate bool) error {
 	switch checks.Mode(mode) {
 	case checks.PreCommit:
-		return runPreCommit(repo, config)
+		return a.runPreCommit(repo)
 
 	case checks.PrePush:
-		return runPrePush(repo, config)
+		return a.runPrePush(repo)
 
 	case checks.ContinuousIntegration:
 		// Always runs all tests on CI.
-		change, err := repo.Between(scm.Current, scm.GitInitialCommit, config.IgnorePatterns)
+		change, err := repo.Between(scm.Current, scm.GitInitialCommit, a.config.IgnorePatterns)
 		if err != nil {
 			return err
 		}
@@ -618,9 +627,9 @@ func cmdRunHook(repo scm.Repo, config *checks.Config, mode string, noUpdate bool
 		prereqReady.Add(1)
 		go func() {
 			defer prereqReady.Done()
-			errCh <- cmdInstallPrereq(repo, config, mode, noUpdate)
+			errCh <- a.cmdInstallPrereq(repo, mode, noUpdate)
 		}()
-		err = runChecks(config, change, mode, &prereqReady)
+		err = a.runChecks(change, mode, &prereqReady)
 		if err2 := <-errCh; err2 != nil {
 			return err2
 		}
@@ -631,9 +640,9 @@ func cmdRunHook(repo scm.Repo, config *checks.Config, mode string, noUpdate bool
 	}
 }
 
-func cmdWriteConfig(repo scm.ReadOnlyRepo, config *checks.Config, configPath string) error {
-	config.MinVersion = version
-	content, err := yaml.Marshal(config)
+func (a *application) cmdWriteConfig(repo scm.ReadOnlyRepo, configPath string) error {
+	a.config.MinVersion = version
+	content, err := yaml.Marshal(a.config)
 	if err != nil {
 		return fmt.Errorf("internal error when marshaling config: %s", err)
 	}
@@ -655,12 +664,15 @@ func mainImpl() error {
 	copy(os.Args[1:], os.Args[2:])
 	os.Args = os.Args[:len(os.Args)-1]
 
+	a := application{}
+
 	verboseFlag := flag.Bool("v", checks.IsContinuousIntegration() || os.Getenv("VERBOSE") != "", "enables verbose logging output")
 	allFlag := flag.Bool("a", false, "runs checks as if all files had been modified")
 	againstFlag := flag.String("r", "", "runs checks on files modified since this revision, as evaluated by your scm repo")
 	noUpdateFlag := flag.Bool("n", false, "disallow using go get even if a prerequisite is missing; bail out instead")
 	configPathFlag := flag.String("c", "pre-commit-go.yml", "file name of the config to load")
-	modeFlag := flag.String("m", "", "coma separated list of modes to process; default depends on the command")
+	modeFlag := flag.String("m", "", "comma separated list of modes to process; default depends on the command")
+	flag.Var(&a.shards, "s", "sharding configuration <current>/<total>")
 	flag.Parse()
 
 	if *allFlag {
@@ -689,7 +701,8 @@ func mainImpl() error {
 		return err
 	}
 
-	configPath, config := loadConfig(repo, *configPathFlag)
+	var configPath string
+	configPath, a.config = loadConfig(repo, *configPathFlag)
 	log.Printf("config: %s", configPath)
 
 	switch cmd {
@@ -713,7 +726,7 @@ func mainImpl() error {
 		b := &bytes.Buffer{}
 		flag.CommandLine.SetOutput(b)
 		flag.CommandLine.PrintDefaults()
-		return cmdHelp(repo, config, b.String())
+		return a.cmdHelp(repo, b.String())
 
 	case "info":
 		if *allFlag != false {
@@ -725,7 +738,7 @@ func mainImpl() error {
 		if *noUpdateFlag != false {
 			return fmt.Errorf("-n can't be used with %s", cmd)
 		}
-		return cmdInfo(repo, config, modes, configPath)
+		return a.cmdInfo(repo, modes, configPath)
 
 	case "install", "i":
 		cmd = "install"
@@ -740,7 +753,7 @@ func mainImpl() error {
 		}
 		var prereqReady sync.WaitGroup
 		prereqReady.Add(1)
-		return cmdInstall(repo, config, modes, *noUpdateFlag, &prereqReady)
+		return a.cmdInstall(repo, modes, *noUpdateFlag, &prereqReady)
 
 	case "installrun":
 		if len(modes) == 0 {
@@ -752,9 +765,9 @@ func mainImpl() error {
 		prereqReady.Add(1)
 		errCh := make(chan error, 1)
 		go func() {
-			errCh <- cmdInstall(repo, config, modes, *noUpdateFlag, &prereqReady)
+			errCh <- a.cmdInstall(repo, modes, *noUpdateFlag, &prereqReady)
 		}()
-		err := cmdRun(repo, config, modes, *againstFlag, &prereqReady)
+		err := a.cmdRun(repo, modes, *againstFlag, &prereqReady)
 		if err2 := <-errCh; err2 != nil {
 			return err2
 		}
@@ -771,7 +784,7 @@ func mainImpl() error {
 		if len(modes) == 0 {
 			modes = checks.AllModes
 		}
-		return cmdInstallPrereq(repo, config, modes, *noUpdateFlag)
+		return a.cmdInstallPrereq(repo, modes, *noUpdateFlag)
 
 	case "run", "r":
 		cmd = "run"
@@ -781,7 +794,7 @@ func mainImpl() error {
 		if len(modes) == 0 {
 			modes = []checks.Mode{checks.PrePush}
 		}
-		return cmdRun(repo, config, modes, *againstFlag, &sync.WaitGroup{})
+		return a.cmdRun(repo, modes, *againstFlag, &sync.WaitGroup{})
 
 	case "run-hook":
 		if modes != nil {
@@ -796,7 +809,7 @@ func mainImpl() error {
 		if flag.NArg() != 1 {
 			return errors.New("run-hook is only meant to be used by hooks")
 		}
-		return cmdRunHook(repo, config, flag.Arg(0), *noUpdateFlag)
+		return a.cmdRunHook(repo, flag.Arg(0), *noUpdateFlag)
 
 	case "version":
 		if modes != nil {
@@ -825,7 +838,7 @@ func mainImpl() error {
 			return fmt.Errorf("-r can't be used with %s", cmd)
 		}
 		// Note that in that case, configPath is ignored and not overritten.
-		return cmdWriteConfig(repo, config, *configPathFlag)
+		return a.cmdWriteConfig(repo, *configPathFlag)
 
 	default:
 		return errors.New("unknown command, try 'help'")

--- a/cmd/pcg/shard.go
+++ b/cmd/pcg/shard.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Daniel Jacques. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var errInvalidShard = errors.New("invalid shard specifier")
+
+type shardFlag struct {
+	current int
+	total   int
+}
+
+var _ flag.Value = (*shardFlag)(nil)
+
+func (s *shardFlag) currentShard() int {
+	return s.current
+}
+
+func (s *shardFlag) totalShards() int {
+	if s.total == 0 {
+		return 1
+	}
+	return s.total
+}
+
+func (s *shardFlag) String() string {
+	return fmt.Sprintf("%d/%d", s.currentShard()+1, s.totalShards())
+}
+
+func (s *shardFlag) Set(v string) error {
+	if v == "" {
+		s.current = 0
+		s.total = 1
+		return nil
+	}
+
+	parts := strings.SplitN(v, "/", 2)
+	if len(parts) != 2 {
+		return errInvalidShard
+	}
+
+	var err error
+	s.current, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("could not parse current shard value: %s", err)
+	}
+	if s.current < 1 {
+		return fmt.Errorf("current shard (%d) must be > 0", s.current)
+	}
+
+	s.total, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("could not parse total shard value: %s", err)
+	}
+	if s.total < s.current {
+		return fmt.Errorf("total shard count must be >= than current (%d < %d)", s.total, s.current)
+	}
+
+	// Zero-index the current shard.
+	s.current--
+	return nil
+}


### PR DESCRIPTION
On LUCI, we're crushing the resources of our builder. The latest issue is OOM errors. This CL adds sharding to PCG, enabling us to break our overall PCG tests into a sequence of consecutive runs. Sharding uses a hash and is opted-in by a Check, which applies some string it derives from each element that it operates on to the sharding function.

Just a thought, plus I wanted to play around with this code base. WDYT?