### PR TITLE
Add a maximum concurrent process throttle.

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -103,8 +103,9 @@ func (b *Build) Run(change scm.Change, options *Options) error {
 	if len(pkgs) == 0 {
 		return nil
 	}
+
 	args := append([]string{"go", "build"}, b.ExtraArgs...)
-	out, _, err := capture(change.Repo(), append(args, pkgs...)...)
+	out, _, err := options.Capture(change.Repo(), append(args, pkgs...)...)
 	if len(out) != 0 {
 		return fmt.Errorf("%s failed: %s", strings.Join(args, " "), out)
 	}
@@ -183,7 +184,7 @@ func (g *Gofmt) Run(change scm.Change, options *Options) error {
 	//
 	// TODO(maruel): Do it in process. It'll be much faster as the content of the
 	// modified files is already in memory.
-	out, _, err := capture(change.Repo(), "gofmt", "-l", "-s", ".")
+	out, _, err := options.Capture(change.Repo(), "gofmt", "-l", "-s", ".")
 	// Split the files to ignore as needed.
 	files := []string{}
 	for _, line := range strings.Split(string(out), "\n") {
@@ -238,7 +239,7 @@ func (t *Test) Run(change scm.Change, options *Options) error {
 				t.ExtraArgs...)
 			args = append(args, testPkg)
 			start := time.Now()
-			out, exitCode, _ := capture(change.Repo(), args...)
+			out, exitCode, _ := options.Capture(change.Repo(), args...)
 			duration := time.Since(start)
 			if duration > time.Second {
 				log.Printf("%s was slow: %s", args, round(duration, time.Millisecond))
@@ -283,7 +284,7 @@ func (e *Errcheck) GetPrerequisites() []CheckPrerequisite {
 func (e *Errcheck) Run(change scm.Change, options *Options) error {
 	// errcheck accepts packages, not files.
 	args := []string{"errcheck", "-ignore", e.Ignores}
-	out, _, err := capture(change.Repo(), append(args, change.Changed().Packages()...)...)
+	out, _, err := options.Capture(change.Repo(), append(args, change.Changed().Packages()...)...)
 	if len(out) != 0 {
 		// TODO(maruel): Process output so paths are relative from
 		// change.Repo().Root().
@@ -322,7 +323,7 @@ func (g *Goimports) GetPrerequisites() []CheckPrerequisite {
 func (g *Goimports) Run(change scm.Change, options *Options) error {
 	// goimports accepts files, not packages.
 	// goimports doesn't return non-zero even if some files need to be updated.
-	out, _, err := capture(change.Repo(), append([]string{"goimports", "-l"}, change.Changed().GoFiles()...)...)
+	out, _, err := options.Capture(change.Repo(), append([]string{"goimports", "-l"}, change.Changed().GoFiles()...)...)
 	if len(out) != 0 {
 		return fmt.Errorf("these files are improperly formmatted, please run: goimports -w <files>\n%s", out)
 	}
@@ -369,7 +370,7 @@ func (g *Golint) Run(change scm.Change, options *Options) error {
 	for _, pkg := range pkgs {
 		go func(p string) {
 			r := []string{}
-			out, _, _ := capture(change.Repo(), "golint", p)
+			out, _, _ := options.Capture(change.Repo(), "golint", p)
 			for _, line := range strings.Split(string(out), "\n") {
 				if len(line) == 0 {
 					continue
@@ -434,7 +435,7 @@ func (g *Govet) Run(change scm.Change, options *Options) error {
 	// - accepts multiple packages per call.
 	// - "." is recursive.
 	// Ignore the return code since we ignore many errors.
-	out, _, _ := capture(change.Repo(), "go", "tool", "vet", "-all", ".")
+	out, _, _ := options.Capture(change.Repo(), "go", "tool", "vet", "-all", ".")
 	result := []string{}
 	files := map[string]bool{}
 	for _, f := range change.Changed().GoFiles() {
@@ -508,7 +509,7 @@ func (c *Custom) GetPrerequisites() []CheckPrerequisite {
 func (c *Custom) Run(change scm.Change, options *Options) error {
 	// TODO(maruel): Make what is passed to the command configurable, e.g. one of:
 	// (Changed, Indirect, All) x (GoFiles, Packages, TestPackages)
-	out, exitCode, err := capture(change.Repo(), c.Command...)
+	out, exitCode, err := options.Capture(change.Repo(), c.Command...)
 	if exitCode != 0 && c.CheckExitCode {
 		return fmt.Errorf("\"%s\" failed with code %d:\n%s", strings.Join(c.Command, " "), exitCode, out)
 	}

--- a/checks/coverage.go
+++ b/checks/coverage.go
@@ -132,7 +132,7 @@ func (c *Coverage) RunProfile(change scm.Change, options *Options) (profile Cove
 	if c.isGoverallsEnabled() {
 		// Please send a pull request if the following doesn't work for you on your
 		// favorite CI system.
-		out, _, err2 := capture(change.Repo(), "goveralls", "-coverprofile", filepath.Join(tmpDir, "profile.cov"))
+		out, _, err2 := options.Capture(change.Repo(), "goveralls", "-coverprofile", filepath.Join(tmpDir, "profile.cov"))
 		// Don't fail the build.
 		if err2 != nil {
 			fmt.Printf("%s", out)
@@ -178,7 +178,7 @@ func (c *Coverage) RunGlobal(change scm.Change, options *Options, tmpDir string)
 				testPkg,
 			}
 			start := time.Now()
-			out, exitCode, err := capture(change.Repo(), args...)
+			out, exitCode, err := options.Capture(change.Repo(), args...)
 			duration := time.Since(start)
 			if duration > time.Second {
 				log.Printf("%s was slow: %s", args, round(duration, time.Millisecond))
@@ -250,7 +250,7 @@ func (c *Coverage) RunLocal(change scm.Change, options *Options, tmpDir string) 
 				testPkg,
 			}
 			start := time.Now()
-			out, exitCode, _ := capture(change.Repo(), args...)
+			out, exitCode, _ := options.Capture(change.Repo(), args...)
 			duration := time.Since(start)
 			if duration > time.Second {
 				log.Printf("%s was slow: %s", args, round(duration, time.Millisecond))

--- a/checks/coverage_test.go
+++ b/checks/coverage_test.go
@@ -40,7 +40,7 @@ func TestCoverageGlobal(t *testing.T) {
 		},
 		PerDir: map[string]*CoverageSettings{},
 	}
-	profile, err := c.RunProfile(change, &Options{1})
+	profile, err := c.RunProfile(change, &Options{MaxDuration: 1})
 	ut.AssertEqual(t, nil, err)
 	expected := CoverageProfile{
 		{
@@ -144,7 +144,7 @@ func TestCoverageLocal(t *testing.T) {
 		},
 		PerDir: map[string]*CoverageSettings{},
 	}
-	profile, err := c.RunProfile(change, &Options{1})
+	profile, err := c.RunProfile(change, &Options{MaxDuration: 1})
 	ut.AssertEqual(t, nil, err)
 	expected := CoverageProfile{
 		{

--- a/checks/utils.go
+++ b/checks/utils.go
@@ -8,9 +8,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"github.com/maruel/pre-commit-go/internal"
-	"github.com/maruel/pre-commit-go/scm"
 )
 
 // IsContinuousIntegration returns true if it thinks it's running on a known CI
@@ -48,11 +45,6 @@ func rsplitn(s, sep string, n int) []string {
 		items[i] = reverse(items[i])
 	}
 	return items
-}
-
-// capture sets GOPATH.
-func capture(r scm.ReadOnlyRepo, args ...string) (string, int, error) {
-	return internal.Capture(r.Root(), []string{"GOPATH=" + r.GOPATH()}, args...)
 }
 
 // round rounds a time.Duration at round.


### PR DESCRIPTION
Follow-on to #4 , going with the maximum concurrent processes approach.

Note that this doesn't constrain the number of goroutines *waiting* for a process token, but that's probably fine.