### PR TITLE
Create token channel *after* Options merge.

### DIFF
--- a/checks/config.go
+++ b/checks/config.go
@@ -70,16 +70,17 @@ type Config struct {
 func (c *Config) EnabledChecks(modes []Mode) ([]Check, *Options) {
 	out := []Check{}
 	options := &Options{}
-	if c.MaxConcurrent > 0 {
-		// Allocate and populate a run token semaphore.
-		options.runTokens = make(chan struct{}, c.MaxConcurrent)
-	}
 
 	for _, mode := range modes {
 		for _, checks := range c.Modes[mode].Checks {
 			out = append(out, checks...)
 		}
 		options = options.merge(c.Modes[mode].Options)
+	}
+
+	if c.MaxConcurrent > 0 {
+		// Allocate and populate a run token semaphore.
+		options.runTokens = make(chan struct{}, c.MaxConcurrent)
 	}
 	return out, options
 }


### PR DESCRIPTION
The token channel was being created prior to merging Options, which had
a chance of creating a new Options object without the channel. Apply
MaxConcurrent to the Options after merge is complete to ensure that the
setting is honored.

Referencing #13.